### PR TITLE
fix:マイグレーションファイル不足によるデプロイ出来ない状態を解消

### DIFF
--- a/db/migrate/20250707052336_create_gift_records.rb
+++ b/db/migrate/20250707052336_create_gift_records.rb
@@ -1,0 +1,17 @@
+class CreateGiftRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :gift_records do |t|
+      t.string :memo
+      t.string :gift_image
+      t.string :item_name
+      t.integer :amount
+      t.boolean :is_public
+      t.date :gift_at
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+      t.references :gift_person, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
## 概要
マイグレーションファイル不足によるデプロイ出来ない状態を解消。
消去していたgift_recordのマイグレーションファイルを再配置。
