### PR TITLE
fix:render_build.sh修正

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,5 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:migrate
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1  bundle exec rails db:migrate:reset
+


### PR DESCRIPTION
## 概要
テーブル重複のため、render_build.shを修正。
DISABLE_DATABASE_ENVIRONMENT_CHECK=1  bundle exec rails db:migrate:resetを追加。
この後修正予定です。