### PR TITLE
fix:render_build.shを元に戻す。

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,5 +3,4 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-DISABLE_DATABASE_ENVIRONMENT_CHECK=1  bundle exec rails db:migrate:reset
-
+bundle exec rails db:migrate


### PR DESCRIPTION
##概要
テーブル重複のため、render_build.shにDISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:resetを追加しましたが、元に戻します。