### PR TITLE
fix:20250722022334_remove_gift_record_id_from_gift_people

### DIFF
--- a/db/migrate/20250722022334_remove_gift_record_id_from_gift_people.rb
+++ b/db/migrate/20250722022334_remove_gift_record_id_from_gift_people.rb
@@ -1,0 +1,6 @@
+class RemoveGiftRecordIdFromGiftPeople < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :gift_people, :gift_records
+    remove_reference :gift_people, :gift_record, index: true
+  end
+end


### PR DESCRIPTION
## 概要
本番環境のgift_peopleテーブルのgift_record_idのNot nullエラーのための修正。

## 主な変更点
以下を変更
- 20250722022334_remove_gift_record_id_from_gift_peopleを追加

## 関連Issue
#58 