### PR TITLE
style:ボタンの色を統一

### DIFF
--- a/app/.claude/CLAUDE.md
+++ b/app/.claude/CLAUDE.md
@@ -1,4 +1,8 @@
 # グローバルルール
 - 日本語で返信すること
 - コード生成を求められた場合は、変更部分のみをわかりやすく説明し、提示すること
--
+
+# コーディング原則
+・YAGNI（You Aren't Gonna Need It）：今必要じゃない機能は作らない
+・DRY（Don't Repeat Yourself）：重複するコードは関数化やモジュール化する。
+・KISS（Keep It Simple Stupid）：複雑な解決策より単純な解決策を優先

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,13 +2,24 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-
 @layer components {
   .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
+    @apply inline-block px-4 py-2 bg-primary text-white rounded-lg font-semibold text-center transition-all duration-200 ease-in-out;
+    @apply hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50;
+    @apply active:bg-primary-dark transform active:scale-95;
+  }
+  
+  .btn-primary-outline {
+    @apply inline-block px-4 py-2 border-2 border-primary text-primary rounded-lg font-semibold text-center transition-all duration-200 ease-in-out;
+    @apply hover:bg-primary hover:text-white focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50;
+  }
+  
+  .btn-primary-sm {
+    @apply btn-primary px-3 py-1.5 text-sm;
+  }
+  
+  .btn-primary-lg {
+    @apply btn-primary px-6 py-3 text-lg;
   }
 }
-
-*/
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -139,7 +139,7 @@
         <%= f.submit "新規登録", style: "
           width: 100%;
           padding: 16px;
-          background: linear-gradient(135deg, #F6B352 100%);
+          background: linear-gradient(135deg, #FC913A 100%);
           color: white;
           border: none;
           border-radius: 8px;

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -7,7 +7,7 @@
     display: inline-block;
     width: 100%;
     padding: 16px;
-    background: linear-gradient(135deg, #F6B352 100%);
+    background: linear-gradient(135deg, #FC913A 100%);
     color: white;
     text-decoration: none;
     border-radius: 8px;

--- a/app/views/gift_people/_form.html.erb
+++ b/app/views/gift_people/_form.html.erb
@@ -244,7 +244,7 @@
     <%= f.submit nil, style: "
       width: 100%;
       padding: 16px;
-      background: linear-gradient(135deg, #F6B352 100%);
+      background: linear-gradient(135deg, #FC913A 100%);
       color: white;
       border: none;
       border-radius: 8px;
@@ -264,7 +264,7 @@ document.addEventListener('DOMContentLoaded', function() {
   
   inputs.forEach(function(input) {
     input.addEventListener('focus', function() {
-      this.style.borderColor = '#F6B352';
+      this.style.borderColor = '#FC913A';
     });
     
     input.addEventListener('blur', function() {

--- a/app/views/gift_people/edit.html.erb
+++ b/app/views/gift_people/edit.html.erb
@@ -9,7 +9,7 @@
         <i class="fas fa-arrow-left text-lg"></i>
       <% end %>
       <h2 class="text-2xl font-bold text-gray-800">
-        <i class="fas fa-user-edit mr-2 text-pink-500"></i>
+        <i class="fas fa-user-edit mr-2 text-primary"></i>
         ギフト相手の編集
       </h2>
     </div>
@@ -47,7 +47,7 @@
           <% end %>
           <% gift_count = current_user.gift_records.where(gift_people_id: @gift_person.id).count %>
           <div class="flex items-center">
-            <i class="fas fa-gift text-pink-500 mr-2"></i>
+            <i class="fas fa-gift text-primary mr-2"></i>
             <span>ギフト記録: <%= pluralize(gift_count, "件") %></span>
           </div>
         </div>
@@ -75,13 +75,13 @@
     <div class="mt-6 pt-6 border-t border-gray-200 flex justify-between">
       <div class="flex space-x-3">
         <%= link_to gift_person_path(@gift_person), 
-            class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+            class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
           <i class="fas fa-eye mr-2"></i>
           詳細を見る
         <% end %>
         
         <%= link_to gift_people_path, 
-            class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+            class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
           <i class="fas fa-list mr-2"></i>
           一覧に戻る
         <% end %>
@@ -94,7 +94,7 @@
 /* フォーカス時のスタイル調整 */
 input:focus, select:focus, textarea:focus {
   outline: none;
-  border-color: #F6B352 !important;
+  border-color: #FC913A !important;
   box-shadow: 0 0 0 3px rgba(246, 179, 82, 0.1);
 }
 </style>

--- a/app/views/gift_people/index.html.erb
+++ b/app/views/gift_people/index.html.erb
@@ -5,12 +5,12 @@
 <!-- ヘッダー部分 -->
 <div class="mb-2 mt-2 text-center">
   <h2 class="text-2xl font-bold text-gray-800 mb-3">
-    <i class="fas fa-users mr-2 text-pink-500"></i>
+    <i class="fas fa-users mr-2 text-primary"></i>
     ギフト相手一覧
   </h2>
   <div class="flex justify-center">
     <%= link_to new_gift_person_path,
-        class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+        class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
       <i class="fas fa-plus mr-2"></i>
       新しい相手を追加
     <% end %>
@@ -30,7 +30,7 @@
               placeholder: "名前、好きなもの、メモで検索",
               id: "search-input",
               autocomplete: "off",
-              class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500" %>
+              class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary" %>
           
           <!-- オートコンプリートドロップダウン -->
           <div id="autocomplete-dropdown" 
@@ -47,7 +47,7 @@
 
         <!-- 検索ボタン -->
         <div class="flex items-end">
-          <%= f.submit "検索", class: "w-full px-3 py-1.5 bg-pink-600 text-white text-sm font-medium rounded-md hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" %>
+          <%= f.submit "検索", class: "w-full px-3 py-1.5 btn-primary text-white text-sm font-medium rounded-md hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" %>
         </div>
       </div>
 
@@ -65,7 +65,7 @@
               {},
               { 
                 id: "people-filter-type-select",
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500" 
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary" 
               } %>
           <%= f.hidden_field :filter_type, id: "people-filter-type-hidden" %>
         </div>
@@ -80,7 +80,7 @@
               {},
               { 
                 id: "people-relationship-select",
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500",
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary",
                 style: (params[:filter_type] == "relationship" ? "" : "display: none;")
               } %>
           
@@ -90,7 +90,7 @@
               {},
               { 
                 id: "people-event-select",
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500",
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary",
                 style: (params[:filter_type] == "event" ? "" : "display: none;")
               } %>
           
@@ -113,7 +113,7 @@
               ], params[:sort_by]),
               { prompt: "選択してください" },
               { 
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500" 
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary" 
               } %>
         </div>
 
@@ -127,7 +127,7 @@
               ], params[:sort_order]),
               { prompt: "選択してください" },
               { 
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500" 
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary" 
               } %>
         </div>
       </div>
@@ -137,7 +137,7 @@
           <span class="text-xs text-gray-600">
             <%= pluralize(@total_people, "件") %>の結果
           </span>
-          <%= link_to "クリア", gift_people_path, class: "text-xs text-pink-600 hover:text-pink-700" %>
+          <%= link_to "クリア", gift_people_path, class: "text-xs text-primary hover:text-primary-hover" %>
         </div>
       <% end %>
     <% end %>
@@ -154,7 +154,7 @@
   <!-- ギフト相手一覧 -->
   <div class="text-center mb-3 mt-1">
     <h3 class="text-base font-medium text-gray-800">
-      <i class="fas fa-address-book mr-1 text-pink-500"></i>
+      <i class="fas fa-address-book mr-1 text-primary"></i>
       登録済み相手
       <span class="text-sm text-gray-500 font-normal ml-1">
         （<%= pluralize(@total_people, "人") %>）
@@ -170,7 +170,7 @@
           <!-- アイコンエリア -->
           <div class="h-32 bg-gradient-to-br from-pink-50 to-purple-50 flex items-center justify-center relative">
             <div class="w-16 h-16 bg-white rounded-full flex items-center justify-center shadow-sm">
-              <i class="fas fa-user text-2xl text-pink-500"></i>
+              <i class="fas fa-user text-2xl text-primary"></i>
             </div>
             
             <!-- 操作ボタン（右上） -->
@@ -248,7 +248,7 @@
             <div class="mt-3 pt-2 border-t border-gray-200">
               <div class="flex items-center justify-between text-sm">
                 <span class="text-gray-500">ギフト記録</span>
-                <span class="font-medium text-pink-600">
+                <span class="font-medium text-primary">
                   <%= pluralize(gift_count, "件") %>
                 </span>
               </div>
@@ -293,7 +293,7 @@
           <% end %>
         <% end %>
         <%= link_to new_gift_person_path,
-            class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+            class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
           <i class="fas fa-plus mr-2"></i>
           最初の相手を登録
         <% end %>
@@ -405,12 +405,12 @@
       const typeLabel = getTypeLabel(result.type);
       
       return `
-        <div class="autocomplete-item px-3 py-2 hover:bg-pink-50 cursor-pointer border-b border-gray-100 last:border-b-0" 
+        <div class="autocomplete-item px-3 py-2 hover:bg-primary-50 cursor-pointer border-b border-gray-100 last:border-b-0" 
              data-name="${escapeHtml(result.name)}" 
              data-id="${result.id}">
           <div class="flex items-start space-x-2">
-            <div class="flex-shrink-0 w-6 h-6 bg-pink-100 rounded-full flex items-center justify-center">
-              <i class="${typeIcon} text-pink-600 text-xs"></i>
+            <div class="flex-shrink-0 w-6 h-6 bg-primary-100 rounded-full flex items-center justify-center">
+              <i class="${typeIcon} text-primary text-xs"></i>
             </div>
             <div class="flex-1 min-w-0">
               <div class="text-xs font-medium text-gray-900">
@@ -496,25 +496,25 @@
   // キーボードナビゲーション
   searchInput.addEventListener('keydown', function(e) {
     const items = dropdown.querySelectorAll('.autocomplete-item');
-    const activeItem = dropdown.querySelector('.autocomplete-item.bg-pink-100');
+    const activeItem = dropdown.querySelector('.autocomplete-item.bg-primary-100');
     
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       if (activeItem) {
-        activeItem.classList.remove('bg-pink-100');
+        activeItem.classList.remove('bg-primary-100');
         const next = activeItem.nextElementSibling || items[0];
-        next.classList.add('bg-pink-100');
+        next.classList.add('bg-primary-100');
       } else if (items.length > 0) {
-        items[0].classList.add('bg-pink-100');
+        items[0].classList.add('bg-primary-100');
       }
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       if (activeItem) {
-        activeItem.classList.remove('bg-pink-100');
+        activeItem.classList.remove('bg-primary-100');
         const prev = activeItem.previousElementSibling || items[items.length - 1];
-        prev.classList.add('bg-pink-100');
+        prev.classList.add('bg-primary-100');
       } else if (items.length > 0) {
-        items[items.length - 1].classList.add('bg-pink-100');
+        items[items.length - 1].classList.add('bg-primary-100');
       }
     } else if (e.key === 'Enter') {
       if (activeItem) {

--- a/app/views/gift_people/new.html.erb
+++ b/app/views/gift_people/new.html.erb
@@ -9,7 +9,7 @@
         <i class="fas fa-arrow-left text-lg"></i>
       <% end %>
       <h2 class="text-2xl font-bold text-gray-800">
-        <i class="fas fa-user-plus mr-2 text-pink-500"></i>
+        <i class="fas fa-user-plus mr-2 text-primary"></i>
         ギフト相手の追加
       </h2>
     </div>
@@ -47,7 +47,7 @@
     <!-- 戻るボタン -->
     <div class="mt-6 pt-6 border-t border-gray-200">
       <%= link_to gift_people_path, 
-          class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+          class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
         <i class="fas fa-times mr-2"></i>
         キャンセル
       <% end %>
@@ -63,7 +63,7 @@
   </h4>
   
   <div class="space-y-3 text-sm text-gray-600">
-    <div class="border-l-4 border-pink-200 pl-3">
+    <div class="border-l-4 border-primary-light pl-3">
       <strong class="text-gray-800">名前</strong><br>
       本名でもニックネームでも構いません。識別しやすい名前を入力してください。
     </div>
@@ -101,7 +101,7 @@
 /* フォーカス時のスタイル調整 */
 input:focus, select:focus, textarea:focus {
   outline: none;
-  border-color: #F6B352 !important;
+  border-color: #FC913A !important;
   box-shadow: 0 0 0 3px rgba(246, 179, 82, 0.1);
 }
 

--- a/app/views/gift_people/show.html.erb
+++ b/app/views/gift_people/show.html.erb
@@ -8,7 +8,7 @@
         <i class="fas fa-arrow-left text-lg"></i>
       <% end %>
       <h2 class="text-2xl font-bold text-gray-800">
-        <i class="fas fa-user mr-2 text-pink-500"></i>
+        <i class="fas fa-user mr-2 text-primary"></i>
         <%= @gift_person.name %>さんの詳細
       </h2>
     </div>
@@ -22,7 +22,7 @@
       <% end %>
       
       <%= link_to new_gift_record_path(gift_person_id: @gift_person.id),
-          class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+          class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
         <i class="fas fa-gift mr-2"></i>
         ギフト記録を追加
       <% end %>
@@ -98,7 +98,7 @@
         <div class="bg-pink-50 rounded-lg p-4">
           <div class="flex items-center justify-between">
             <span class="text-sm font-medium text-gray-600">総ギフト数</span>
-            <span class="text-2xl font-bold text-pink-600">
+            <span class="text-2xl font-bold text-primary">
               <%= @gift_records.count %>件
             </span>
           </div>
@@ -175,13 +175,13 @@
 <div class="bg-white rounded-lg shadow-md border border-gray-200 p-6">
   <div class="flex items-center justify-between mb-6">
     <h3 class="text-lg font-medium text-gray-800">
-      <i class="fas fa-gifts mr-2 text-pink-500"></i>
+      <i class="fas fa-gifts mr-2 text-primary"></i>
       ギフト記録（<%= pluralize(@gift_records.count, "件") %>）
     </h3>
     
     <% if @gift_records.any? %>
       <%= link_to gift_records_path(gift_person_id: @gift_person.id),
-          class: "text-sm text-pink-600 hover:text-pink-700 font-medium" do %>
+          class: "text-sm text-primary hover:text-primary-hover font-medium" do %>
         すべて見る →
       <% end %>
     <% end %>
@@ -241,7 +241,7 @@
         <%= @gift_person.name %>さんへのギフト記録を作成してみましょう。
       </p>
       <%= link_to new_gift_record_path(gift_person_id: @gift_person.id),
-          class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+          class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
         <i class="fas fa-plus mr-2"></i>
         最初のギフト記録を作成
       <% end %>
@@ -264,7 +264,7 @@
     <% end %>
     
     <%= link_to new_gift_record_path(gift_person_id: @gift_person.id),
-        class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+        class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
       <i class="fas fa-plus mr-2"></i>
       ギフト記録を追加
     <% end %>

--- a/app/views/gift_records/_form.html.erb
+++ b/app/views/gift_records/_form.html.erb
@@ -587,7 +587,7 @@
     <%= f.submit nil, style: "
       width: 100%;
       padding: 16px;
-      background: linear-gradient(135deg, #F6B352 100%);
+      background: linear-gradient(135deg, #FC913A 100%);
       color: white;
       border: none;
       border-radius: 8px;

--- a/app/views/gift_records/edit.html.erb
+++ b/app/views/gift_records/edit.html.erb
@@ -5,7 +5,7 @@
 <nav class="flex mb-6" aria-label="Breadcrumb">
   <ol class="inline-flex items-center space-x-1 md:space-x-3">
     <li class="inline-flex items-center">
-      <%= link_to gift_records_path, class: "inline-flex items-center text-sm font-medium text-gray-700 hover:text-pink-600" do %>
+      <%= link_to gift_records_path, class: "inline-flex items-center text-sm font-medium text-gray-700 hover:text-primary" do %>
         <i class="fas fa-home mr-2"></i>
         ギフト記録一覧
       <% end %>
@@ -13,7 +13,7 @@
     <li>
       <div class="flex items-center">
         <i class="fas fa-chevron-right text-gray-400 mx-2"></i>
-        <%= link_to @gift_record, class: "text-sm font-medium text-gray-700 hover:text-pink-600" do %>
+        <%= link_to @gift_record, class: "text-sm font-medium text-gray-700 hover:text-primary" do %>
           <%= truncate(@gift_record.display_item_name, length: 20) %>
         <% end %>
       </div>
@@ -124,7 +124,7 @@
         
         <div class="flex space-x-3">
           <%= link_to @gift_record, 
-              class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+              class: "inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
             <i class="fas fa-times mr-2"></i>
             キャンセル
           <% end %>

--- a/app/views/gift_records/index.html.erb
+++ b/app/views/gift_records/index.html.erb
@@ -5,13 +5,13 @@
 <!-- ヘッダー部分 -->
 <div class="mb-2 mt-2 text-center">
   <h2 class="text-2xl font-bold text-gray-800 mb-3">
-    <i class="fas fa-gift mr-2 text-pink-500"></i>
+    <i class="fas fa-gift mr-2 text-primary"></i>
     ギフト記録一覧
   </h2>
   <% if user_signed_in? %>
     <div class="flex justify-center">
       <%= link_to new_gift_record_path,
-          class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+          class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
         <i class="fas fa-plus mr-2"></i>
         新しい記録を作成
       <% end %>
@@ -32,7 +32,7 @@
               placeholder: "アイテム名、メモで検索",
               id: "gift-records-search-input",
               autocomplete: "off",
-              class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500" %>
+              class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary" %>
           
           <!-- オートコンプリートドロップダウン -->
           <div id="gift-records-autocomplete-dropdown" 
@@ -49,7 +49,7 @@
 
         <!-- 検索ボタン -->
         <div class="flex items-end">
-          <%= f.submit "検索", class: "w-full px-3 py-1.5 bg-pink-600 text-white text-sm font-medium rounded-md hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" %>
+          <%= f.submit "検索", class: "w-full px-3 py-1.5 btn-primary text-white text-sm font-medium rounded-md hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" %>
         </div>
       </div>
 
@@ -67,7 +67,7 @@
               {},
               { 
                 id: "filter-type-select",
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500" 
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary" 
               } %>
           <%= f.hidden_field :filter_type, id: "filter-type-hidden" %>
         </div>
@@ -82,7 +82,7 @@
               {},
               { 
                 id: "relationship-select",
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500",
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary",
                 style: (params[:filter_type] == "relationship" ? "" : "display: none;")
               } %>
           
@@ -92,7 +92,7 @@
               {},
               { 
                 id: "event-select",
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500",
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary",
                 style: (params[:filter_type] == "event" ? "" : "display: none;")
               } %>
           
@@ -116,7 +116,7 @@
               ], params[:sort_by]),
               { prompt: "選択してください" },
               { 
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500" 
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary" 
               } %>
         </div>
 
@@ -130,7 +130,7 @@
               ], params[:sort_order]),
               { prompt: "選択してください" },
               { 
-                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-pink-500 focus:border-pink-500" 
+                class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary" 
               } %>
         </div>
       </div>
@@ -140,7 +140,7 @@
           <span class="text-xs text-gray-600">
             <%= pluralize(@total_records, "件") %>の結果
           </span>
-          <%= link_to "クリア", gift_records_path, class: "text-xs text-pink-600 hover:text-pink-700" %>
+          <%= link_to "クリア", gift_records_path, class: "text-xs text-primary hover:text-primary-hover" %>
         </div>
       <% end %>
     <% end %>
@@ -157,7 +157,7 @@
   <!-- ギフト記録一覧 -->
   <div class="text-center mb-3 mt-1">
     <h3 class="text-base font-medium text-gray-800">
-      <i class="fas fa-th-large mr-1 text-pink-500"></i>
+      <i class="fas fa-th-large mr-1 text-primary"></i>
       記録一覧
       <span class="text-sm text-gray-500 font-normal ml-1">
         （<%= pluralize(@total_records, "件") %>）
@@ -176,7 +176,7 @@
               <!-- 将来の画像配置用プレースホルダー -->
               <div class="text-center">
                 <div class="w-16 h-16 sm:w-18 sm:h-18 lg:w-18 lg:h-18 xl:w-20 xl:h-20 mx-auto mb-2 sm:mb-3 bg-white rounded-full flex items-center justify-center shadow-sm">
-                  <i class="fas fa-gift text-2xl sm:text-2xl lg:text-2xl xl:text-3xl text-pink-500"></i>
+                  <i class="fas fa-gift text-2xl sm:text-2xl lg:text-2xl xl:text-3xl text-primary"></i>
                 </div>
                 <p class="text-base sm:text-base lg:text-sm xl:text-base text-gray-500">画像エリア</p>
               </div>
@@ -359,7 +359,7 @@
           <% end %>
           <% if user_signed_in? %>
             <%= link_to new_gift_record_path,
-                class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+                class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
               <i class="fas fa-plus mr-2"></i>
               <% if params[:search].present? %>新しい記録を作成<% else %>最初の記録を作成<% end %>
             <% end %>
@@ -478,12 +478,12 @@
       const typeLabel = getTypeLabel(result.type);
       
       return `
-        <div class="autocomplete-item px-3 py-2 hover:bg-pink-50 cursor-pointer border-b border-gray-100 last:border-b-0" 
+        <div class="autocomplete-item px-3 py-2 hover:bg-primary-50 cursor-pointer border-b border-gray-100 last:border-b-0" 
              data-display-text="${escapeHtml(result.display_text)}" 
              data-id="${result.id}">
           <div class="flex items-start space-x-2">
-            <div class="flex-shrink-0 w-6 h-6 bg-pink-100 rounded-full flex items-center justify-center">
-              <i class="${typeIcon} text-pink-600 text-xs"></i>
+            <div class="flex-shrink-0 w-6 h-6 bg-primary-100 rounded-full flex items-center justify-center">
+              <i class="${typeIcon} text-primary text-xs"></i>
             </div>
             <div class="flex-1 min-w-0">
               <div class="text-xs font-medium text-gray-900">
@@ -567,25 +567,25 @@
   // キーボードナビゲーション
   searchInput.addEventListener('keydown', function(e) {
     const items = dropdown.querySelectorAll('.autocomplete-item');
-    const activeItem = dropdown.querySelector('.autocomplete-item.bg-pink-100');
+    const activeItem = dropdown.querySelector('.autocomplete-item.bg-primary-100');
     
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       if (activeItem) {
-        activeItem.classList.remove('bg-pink-100');
+        activeItem.classList.remove('bg-primary-100');
         const next = activeItem.nextElementSibling || items[0];
-        next.classList.add('bg-pink-100');
+        next.classList.add('bg-primary-100');
       } else if (items.length > 0) {
-        items[0].classList.add('bg-pink-100');
+        items[0].classList.add('bg-primary-100');
       }
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       if (activeItem) {
-        activeItem.classList.remove('bg-pink-100');
+        activeItem.classList.remove('bg-primary-100');
         const prev = activeItem.previousElementSibling || items[items.length - 1];
-        prev.classList.add('bg-pink-100');
+        prev.classList.add('bg-primary-100');
       } else if (items.length > 0) {
-        items[items.length - 1].classList.add('bg-pink-100');
+        items[items.length - 1].classList.add('bg-primary-100');
       }
     } else if (e.key === 'Enter') {
       if (activeItem) {
@@ -716,8 +716,8 @@
     // プレビュー内容を生成
     const previewHTML = `
       <div class="flex items-start space-x-3">
-        <div class="flex-shrink-0 w-12 h-12 bg-pink-100 rounded-full flex items-center justify-center">
-          <i class="fas fa-gift text-pink-600"></i>
+        <div class="flex-shrink-0 w-12 h-12 bg-primary-100 rounded-full flex items-center justify-center">
+          <i class="fas fa-gift text-primary"></i>
         </div>
         <div class="flex-1 min-w-0">
           <div class="text-sm font-medium text-gray-900">

--- a/app/views/gift_records/show.html.erb
+++ b/app/views/gift_records/show.html.erb
@@ -102,7 +102,7 @@
       <!-- 贈り先情報 -->
       <div>
         <h2 class="text-lg font-semibold text-gray-900 mb-4 flex items-center">
-          <i class="fas fa-user text-pink-500 mr-2"></i>
+          <i class="fas fa-user text-primary mr-2"></i>
           贈り先情報
         </h2>
         
@@ -210,7 +210,7 @@
       </div>
       <div>
         <%= link_to gift_records_path, 
-            class: "inline-flex items-center text-pink-600 hover:text-pink-700 font-medium" do %>
+            class: "inline-flex items-center text-primary hover:text-primary-hover font-medium" do %>
           <i class="fas fa-arrow-left mr-1"></i>
           一覧に戻る
         <% end %>
@@ -222,7 +222,7 @@
 <!-- 関連アクション -->
 <div class="mt-6 text-center">
   <%= link_to new_gift_record_path, 
-      class: "inline-flex items-center px-6 py-3 text-sm font-medium text-white bg-pink-600 border border-transparent rounded-lg shadow-sm hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-offset-2 transition-colors" do %>
+      class: "inline-flex items-center px-6 py-3 text-sm font-medium text-white btn-primary border border-transparent rounded-lg shadow-sm hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors" do %>
     <i class="fas fa-plus mr-2"></i>
     新しい記録を作成
   <% end %>

--- a/app/views/reminds/edit.html.erb
+++ b/app/views/reminds/edit.html.erb
@@ -219,7 +219,7 @@
   <!-- 関連情報 -->
   <div class="mt-8 bg-white rounded-lg shadow-md border border-gray-200 p-6">
     <h3 class="text-lg font-medium text-gray-800 mb-4">
-      <i class="fas fa-gift mr-2 text-pink-500"></i>
+      <i class="fas fa-gift mr-2 text-primary"></i>
       <%= @remind.gift_person.name %>さんへの過去のギフト記録
     </h3>
     

--- a/app/views/reminds/index.html.erb
+++ b/app/views/reminds/index.html.erb
@@ -144,7 +144,7 @@
           <!-- 関係性 -->
           <div class="mb-2">
             <div class="flex items-center text-sm">
-              <i class="fas fa-heart mr-2 text-pink-500"></i>
+              <i class="fas fa-heart mr-2 text-primary"></i>
               <span class="text-gray-600">
                 <%= remind.gift_person.relationship&.name || "未設定" %>
               </span>

--- a/app/views/reminds/show.html.erb
+++ b/app/views/reminds/show.html.erb
@@ -149,7 +149,7 @@
   <!-- 関連ギフト記録 -->
   <div class="bg-white rounded-lg shadow-md border border-gray-200 p-6">
     <h3 class="text-lg font-medium text-gray-800 mb-4">
-      <i class="fas fa-gift mr-2 text-pink-500"></i>
+      <i class="fas fa-gift mr-2 text-primary"></i>
       <%= @remind.gift_person.name %>さんへのギフト記録
     </h3>
     
@@ -204,7 +204,7 @@
         </div>
         <p class="text-gray-500 mb-4">まだギフト記録がありません</p>
         <%= link_to new_gift_record_path(gift_people_id: @remind.gift_person_id), 
-            class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+            class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
           <i class="fas fa-plus mr-2"></i>
           最初のギフト記録を作成
         <% end %>

--- a/app/views/static_pages/how_to_use.html.erb
+++ b/app/views/static_pages/how_to_use.html.erb
@@ -76,7 +76,7 @@
     <!-- ステップ4 -->
     <div class="bg-white rounded-lg shadow-md p-8">
       <div class="flex items-center mb-6">
-        <div class="w-12 h-12 bg-pink-600 text-white rounded-full flex items-center justify-center font-bold text-lg mr-4">
+        <div class="w-12 h-12 btn-primary text-white rounded-full flex items-center justify-center font-bold text-lg mr-4">
           4
         </div>
         <h2 class="text-2xl font-bold text-gray-800">記録を活用する</h2>
@@ -145,7 +145,7 @@
     <h3 class="text-2xl font-bold text-gray-800 mb-4">さあ、始めましょう！</h3>
     <% if user_signed_in? %>
       <%= link_to new_gift_record_path, 
-          class: "inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-pink-600 hover:bg-pink-700 transition-colors duration-300 shadow-lg hover:shadow-xl" do %>
+          class: "inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white btn-primary hover:bg-primary-hover transition-colors duration-300 shadow-lg hover:shadow-xl" do %>
         <i class="fas fa-plus mr-2"></i>
         最初の記録を作成
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,7 @@
   <div class="flex items-center justify-between mb-4">
     <div class="flex items-center">
       <h2 class="text-2xl font-bold text-gray-800">
-        <i class="fas fa-user-circle mr-2 text-pink-500"></i>
+        <i class="fas fa-user-circle mr-2 text-primary"></i>
         マイページ
       </h2>
     </div>
@@ -20,7 +20,7 @@
       <% end %>
       
       <%= link_to new_gift_record_path,
-          class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-pink-500" do %>
+          class: "inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white btn-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" do %>
         <i class="fas fa-plus mr-2"></i>
         新しいギフト記録
       <% end %>
@@ -32,7 +32,7 @@
     <!-- ユーザー基本情報 -->
     <div class="flex items-center mb-6">
       <div class="w-16 h-16 bg-pink-100 rounded-full flex items-center justify-center mr-4">
-        <i class="fas fa-user text-2xl text-pink-600"></i>
+        <i class="fas fa-user text-2xl text-primary"></i>
       </div>
       <div class="flex-1">
         <h3 class="text-xl font-semibold text-gray-800"><%= @user.display_name %></h3>
@@ -56,7 +56,7 @@
       <div class="bg-pink-50 rounded-lg p-4">
         <div class="flex items-center">
           <div class="w-10 h-10 bg-pink-100 rounded-lg flex items-center justify-center mr-3">
-            <i class="fas fa-gift text-pink-600"></i>
+            <i class="fas fa-gift text-primary"></i>
           </div>
           <div>
             <p class="text-sm font-medium text-gray-600">総ギフト数</p>
@@ -162,7 +162,7 @@
         <i class="fas fa-star mr-2 text-yellow-500"></i>
         よくギフトを贈る相手 TOP5
       </h3>
-      <%= link_to gift_people_path, class: "text-sm text-pink-600 hover:text-pink-700 font-medium" do %>
+      <%= link_to gift_people_path, class: "text-sm text-primary hover:text-primary-hover font-medium" do %>
         管理する →
       <% end %>
     </div>
@@ -183,7 +183,7 @@
             </div>
             <div class="text-right">
               <% gift_count = current_user.gift_records.where(gift_people_id: person.id).count %>
-              <span class="text-sm font-medium text-pink-600">
+              <span class="text-sm font-medium text-primary">
                 <%= pluralize(gift_count, "件") %>
               </span>
             </div>
@@ -196,7 +196,7 @@
           <i class="fas fa-users text-2xl text-gray-400"></i>
         </div>
         <p class="text-gray-500">まだギフト相手が登録されていません</p>
-        <%= link_to new_gift_person_path, class: "inline-flex items-center mt-2 text-sm text-pink-600 hover:text-pink-700 font-medium" do %>
+        <%= link_to new_gift_person_path, class: "inline-flex items-center mt-2 text-sm text-primary hover:text-primary-hover font-medium" do %>
           <i class="fas fa-plus mr-1"></i>
           ギフト相手を追加
         <% end %>
@@ -211,7 +211,7 @@
         <i class="fas fa-bell mr-2 text-orange-500"></i>
         今後の記念日
       </h3>
-      <%= link_to reminds_path, class: "text-sm text-pink-600 hover:text-pink-700 font-medium" do %>
+      <%= link_to reminds_path, class: "text-sm text-primary hover:text-primary-hover font-medium" do %>
         管理する →
       <% end %>
     </div>
@@ -264,7 +264,7 @@
           <i class="fas fa-bell text-2xl text-gray-400"></i>
         </div>
         <p class="text-gray-500">記念日リマインダーが設定されていません</p>
-        <%= link_to new_remind_path, class: "inline-flex items-center mt-2 text-sm text-pink-600 hover:text-pink-700 font-medium" do %>
+        <%= link_to new_remind_path, class: "inline-flex items-center mt-2 text-sm text-primary hover:text-primary-hover font-medium" do %>
           <i class="fas fa-plus mr-1"></i>
           記念日を設定
         <% end %>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -12,6 +12,12 @@ module.exports = {
       fontFamily: {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans],
       },
+      colors: {
+        'primary': '#FC913A',
+        'primary-hover': '#E8823A',
+        'primary-light': '#FEA560',
+        'primary-dark': '#E07F2F',
+      },
     },
   },
   plugins: [

--- a/db/migrate/20250709021050_create_gift_people.rb
+++ b/db/migrate/20250709021050_create_gift_people.rb
@@ -8,6 +8,7 @@ class CreateGiftPeople < ActiveRecord::Migration[7.2]
       t.string :memo
       t.string :gift_peoples_image
       t.references :user, null: false, foreign_key: true
+      t.references :gift_record, null: false, foreign_key: true
       t.references :relationship, null: false, foreign_key: true
 
       t.timestamps


### PR DESCRIPTION
## 概要
style:ボタンの色を#FC913Aに統一しました。


## 主な変更点
以下を変更
- app/assets/stylesheets/application.tailwind.css
- app/views/devise/registrations/new.html.erb
- app/views/devise/shared/_links.html.erb
- app/views/gift_people/_form.html.erb
- app/views/gift_people/edit.html.erb
- app/views/gift_people/index.html.erb
- app/views/gift_people/new.html.erb
- app/views/gift_people/show.html.erb
- app/views/gift_records/_form.html.erb
- app/views/gift_records/edit.html.erb
- app/views/gift_records/index.html.erb
- app/views/gift_records/show.html.erb
- app/views/reminds/edit.html.erb
- app/views/reminds/index.html.erb
- app/views/reminds/show.html.erb
- app/views/static_pages/how_to_use.html.erb
- app/views/users/show.html.erb
- config/tailwind.config.js

## 関連Issue
#62