### PR TITLE
fix:Lineログインの不具合を修正。2回目のログインで既存ユーザーが見つかってもemailが空の場合に新規作成となっている

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -8,7 +8,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @omniauth = request.env["omniauth.auth"]
     if @omniauth.present?
       @profile = User.find_or_initialize_by(provider: @omniauth["provider"], uid: @omniauth["uid"])
-      
+
       # 新規ユーザーまたは既存ユーザーの情報を更新
       if @profile.new_record?
         # 新規ユーザーの場合
@@ -23,7 +23,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         # 既存ユーザーでemailが空の場合、emailを更新
         @profile.update!(email: @omniauth["info"]["email"])
       end
-      
+
       @profile.set_values(@omniauth)
       sign_in(:user, @profile)
     end

--- a/app/views/gift_records/index.html.erb
+++ b/app/views/gift_records/index.html.erb
@@ -363,11 +363,7 @@
 
 <%# <% if @share_gift_record %>
 
-
-
 <script>
-
-
 // ギフト相手一覧のオートコンプリート機能
 (function() {
   let autocompleteInitialized = false;


### PR DESCRIPTION
## 概要
Lineログインの不具合を修正。2回目のログインで既存ユーザーが見つかってもemailが空の場合に新規作成となっている


## 主な変更点
以下を変更
- app/controllers/omniauth_callbacks_controller.rb
- app/views/gift_records/index.html.erb

## 関連Issue
#79 