### PR TITLE
fix:Lineログイン２回目などでemailがない場合にエラーとなるため修正。line登録の際にサンプルメールアドレスを登録するように修正。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,11 @@ group :development do
   gem "web-console"
 end
 
+group :development, :test do
+  gem "rspec-rails"
+  gem "factory_bot_rails"
+end
+
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    diff-lcs (1.6.2)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
@@ -115,6 +116,11 @@ GEM
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
+    factory_bot (6.5.4)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.0)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     faraday (2.13.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -283,6 +289,23 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.1)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (8.0.1)
+      actionpack (>= 7.2)
+      activesupport (>= 7.2)
+      railties (>= 7.2)
+      rspec-core (~> 3.13)
+      rspec-expectations (~> 3.13)
+      rspec-mocks (~> 3.13)
+      rspec-support (~> 3.13)
+    rspec-support (3.13.4)
     rubocop (1.77.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -392,6 +415,7 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
+  factory_bot_rails
   jbuilder
   jsbundling-rails
   line-bot-api
@@ -401,6 +425,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)
+  rspec-rails
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -12,7 +12,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # 新規ユーザーまたは既存ユーザーの情報を更新
       if @profile.new_record?
         # 新規ユーザーの場合
-        email = @omniauth["info"]["email"].presence  # 空文字列の場合はnilにする
+        email = @omniauth["info"]["email"].presence || fake_email(@omniauth["uid"], @omniauth["provider"])
         @profile.assign_attributes(
           email: email,
           name: @omniauth["info"]["name"],
@@ -33,6 +33,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def fake_email(uid, provider)
-    "#{auth.uid}-#{auth.provider}@example.com"
+    "#{uid}-#{provider}@example.com"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,11 @@ class User < ApplicationRecord
     line_connected? ? "text-green-600" : "text-gray-500"
   end
 
+  # fake emailかどうかを判定
+  def fake_email?
+    email.present? && email.end_with?("@example.com")
+  end
+
   def public_gift_records_count
     gift_records.where(is_public: true).count
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -37,6 +37,14 @@
         <div class="flex-1">
           <h3 class="text-xl font-semibold text-gray-800"><%= @user.display_name %></h3>
           <p class="text-gray-600"><%= @user.display_email %></p>
+          <% if @user.fake_email? %>
+            <div class="mt-2 p-2 bg-yellow-50 border border-yellow-200 rounded-md">
+              <span class="text-yellow-800 text-sm font-medium">
+                <i class="fas fa-info-circle mr-1"></i>
+                LINEで新規登録された場合、仮のメールアドレスが登録されています。メールアドレスを使用する場合、マイページから編集してください。
+              </span>
+            </div>
+          <% end %>
           <div class="text-sm flex items-center mb-1">
             <% if @user.line_connected? %>
               <i class="fab fa-line mr-2 text-green-500"></i>


### PR DESCRIPTION
## 概要
Lineログイン２回目などでemailがない場合にエラーとなるため修正。line登録の際にサンプルメールアドレスを登録するように修正。
そのために使用するfake_emailメソッド作成しました。

## 主な変更点
以下を変更
- app/controllers/omniauth_callbacks_controller.rb
- app/models/user.rb
- app/views/users/show.html.erb
- 

## 関連Issue
#81 