### PR TITLE
fix:マイページのLine連携とメールアドレスについての注意文の表示条件を修正

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -37,7 +37,7 @@
         <div class="flex-1">
           <h3 class="text-xl font-semibold text-gray-800"><%= @user.display_name %></h3>
           <p class="text-gray-600"><%= @user.display_email %></p>
-          <% if @user.fake_email? %>
+          <% if @user.fake_email? && @user.line_connected? %>
             <div class="mt-2 p-2 bg-yellow-50 border border-yellow-200 rounded-md">
               <span class="text-yellow-800 text-sm font-medium">
                 <i class="fas fa-info-circle mr-1"></i>


### PR DESCRIPTION
## 概要
マイページのLine連携とメールアドレスについての注意文の表示条件を修正。
 @user.line_connected?で LINE連携状態を判定するように修正

## 主な変更点
以下を変更
- app/views/users/show.html.erb

## 関連Issue
#103