### PR TITLE
add:ギフトアイテムカテゴリーを追加、お気に入りボタンについて修正

### DIFF
--- a/app/controllers/gift_records_controller.rb
+++ b/app/controllers/gift_records_controller.rb
@@ -352,7 +352,12 @@ class GiftRecordsController < ApplicationController
   private
 
   def gift_record_params
-    params.require(:gift_record).permit(:title, :description, :body, :gift_record_image, :gift_record_image_cache, :gift_people_id, :memo, :item_name, :amount, :gift_at, :event_id, :is_public)
+    params.require(:gift_record).permit(
+      :title, :description, :body,
+      :gift_record_image, :gift_record_image_cache,
+      :gift_people_id, :memo, :item_name, :amount, :gift_at, :event_id, :is_public,
+      :gift_item_category_id
+    )
   end
 
   def gift_person_params

--- a/app/javascript/controllers/favorites_controller.js
+++ b/app/javascript/controllers/favorites_controller.js
@@ -4,10 +4,22 @@ import { getAPIHeaders, showToast } from "../utils"
 // Connects to data-controller="favorites"
 export default class extends Controller {
   static targets = ["button", "heart", "count"]
-  static values = { recordId: Number }
+  static values = { recordId: Number, loginUrl: String }
 
   connect() {
     // No-op: click handled via action on button
+  }
+
+  requireLogin(event) {
+    if (event) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    showToast('お気に入りするにはログインが必要です。', 'error')
+    // ここで自動リダイレクトしたい場合は以下を有効化
+    // if (this.hasLoginUrlValue && this.loginUrlValue) {
+    //   setTimeout(() => { window.location.href = this.loginUrlValue }, 1200)
+    // }
   }
 
   async toggle(event) {

--- a/app/models/gift_item_category.rb
+++ b/app/models/gift_item_category.rb
@@ -1,0 +1,2 @@
+class GiftItemCategory < ApplicationRecord
+end

--- a/app/models/gift_record.rb
+++ b/app/models/gift_record.rb
@@ -4,6 +4,7 @@ class GiftRecord < ApplicationRecord
   belongs_to :event
   belongs_to :gift_person, foreign_key: "gift_people_id"
   has_many :favorites, dependent: :destroy
+  belongs_to :gift_item_category, optional: true
 
   # 必須フィールドのバリデーション（統一されたエラーメッセージ）
   validates :item_name, presence: { message: "を入力してください" }, length: { maximum: 30 }

--- a/app/views/gift_records/_form.html.erb
+++ b/app/views/gift_records/_form.html.erb
@@ -444,6 +444,38 @@
     <% end %>
   </div>
 
+  <!-- アイテムカテゴリー選択 -->
+  <div style="margin-bottom: 24px; text-align: left;">
+    <%= f.label :gift_item_category_id, "アイテムカテゴリー", style: "
+      display: block;
+      margin-bottom: 8px;
+      font-weight: 600;
+      color: #555;
+      font-size: 14px;
+    " %>
+    <%= f.collection_select :gift_item_category_id,
+          GiftItemCategory.order(:name), :id, :name,
+          { include_blank: "選択してください" },
+          {
+            style: "
+              width: 100%;
+              padding: 14px 16px;
+              border: 2px solid #e1e5e9;
+              border-radius: 8px;
+              font-size: 16px;
+              box-sizing: border-box;
+              transition: border-color 0.3s ease;
+            ",
+            id: "gift_record_gift_item_category_id"
+          }
+    %>
+
+    <div style="font-size: 12px; color: #888; margin-top: 8px;">
+      <i class="fas fa-info-circle" style="margin-right: 4px;"></i>
+      任意：アイテムのカテゴリーを選択してください
+    </div>
+  </div>
+
   <!-- ギフト金額入力 -->
   <div style="margin-bottom: 24px; text-align: left;">
     <%= f.label :amount, "金額", style: "

--- a/app/views/shared/_favorite_button.html.erb
+++ b/app/views/shared/_favorite_button.html.erb
@@ -22,14 +22,17 @@
     </button>
   </div>
 <% else %>
-  <%# 未ログインユーザーには静的なハートアイコンのみ表示 %>
   <% favorites_count = Favorite.favorites_count_for_gift_record(gift_record) %>
-  <% if favorites_count > 0 %>
-    <div class="favorite-button-container static">
-      <div class="favorite-button-static">
-        <i class="far fa-heart text-gray-400"></i>
-        <span class="favorite-count-static"><%= favorites_count %></span>
-      </div>
-    </div>
-  <% end %>
+  <div class="favorite-button-container" data-controller="favorites" data-favorites-login-url-value="<%= new_user_session_path %>">
+    <button type="button"
+            class="favorite-button"
+            data-action="click->favorites#requireLogin"
+            title="ログインが必要です"
+            aria-label="ログインが必要です">
+      <i class="favorite-heart far fa-heart"></i>
+      <% if favorites_count > 0 %>
+        <span class="favorite-count" data-favorites-target="count"><%= favorites_count %></span>
+      <% end %>
+    </button>
+  </div>
 <% end %>

--- a/db/migrate/20250813051318_create_gift_item_categories.rb
+++ b/db/migrate/20250813051318_create_gift_item_categories.rb
@@ -1,0 +1,9 @@
+class CreateGiftItemCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :gift_item_categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250813051508_add.rb
+++ b/db/migrate/20250813051508_add.rb
@@ -1,0 +1,4 @@
+class Add < ActiveRecord::Migration[7.2]
+  def change
+  end
+end

--- a/db/migrate/20250813070000_add_gift_item_category_to_gift_records.rb
+++ b/db/migrate/20250813070000_add_gift_item_category_to_gift_records.rb
@@ -1,0 +1,5 @@
+class AddGiftItemCategoryToGiftRecords < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :gift_records, :gift_item_category, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_25_060808) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_13_070000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_25_060808) do
     t.index ["gift_record_id"], name: "index_favorites_on_gift_record_id"
     t.index ["user_id", "gift_record_id"], name: "index_favorites_on_user_id_and_gift_record_id", unique: true
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "gift_item_categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "gift_people", force: :cascade do |t|
@@ -64,8 +70,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_25_060808) do
     t.datetime "updated_at", null: false
     t.bigint "gift_people_id", null: false
     t.bigint "age_id"
+    t.bigint "gift_item_category_id"
     t.index ["age_id"], name: "index_gift_records_on_age_id"
     t.index ["event_id"], name: "index_gift_records_on_event_id"
+    t.index ["gift_item_category_id"], name: "index_gift_records_on_gift_item_category_id"
     t.index ["gift_people_id"], name: "index_gift_records_on_gift_people_id"
     t.index ["user_id"], name: "index_gift_records_on_user_id"
   end
@@ -109,6 +117,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_25_060808) do
   add_foreign_key "gift_people", "users"
   add_foreign_key "gift_records", "ages"
   add_foreign_key "gift_records", "events"
+  add_foreign_key "gift_records", "gift_item_categories"
   add_foreign_key "gift_records", "gift_people", column: "gift_people_id"
   add_foreign_key "gift_records", "users"
   add_foreign_key "reminds", "gift_people"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,6 +75,38 @@ end
 
 puts "年齢データの作成完了: #{Age.count}件の年齢グループが存在します"
 
+# ===== アイテムカテゴリーの作成 =====
+puts "アイテムカテゴリーを作成中..."
+
+gift_item_categories = [
+  'ドリンク',
+  'スイーツ',
+  'フード',
+  'お酒',
+  'ビューティー・ヘルスケア',
+  'インテリア・雑貨',
+  '花',
+  'キッチン・家事',
+  'ファッション',
+  'スポーツ',
+  'ベビー・キッズ',
+  'ペット',
+  'エンタメ・趣味',
+  'ギフトカード',
+  'レジャー施設',
+  'トラベル・ホテル',
+  'カタログギフト',
+  '体験ギフト',
+  '写真'
+]
+
+gift_item_categories.each do |name|
+  GiftItemCategory.find_or_create_by(name: name)
+end
+
+puts "アイテムカテゴリーの作成完了: #{GiftItemCategory.count}件のカテゴリが存在します"
+
+
 # ===== データ整合性チェック =====
 puts "\n=== データ整合性チェック ==="
 puts "Events count: #{Event.count}"


### PR DESCRIPTION
## 概要
ギフトアイテムカテゴリーを追加
未ログイン時にお気に入りボタンを押した際に「お気に入りするにはログインが必要です」と出るように修正

## 主な変更点
以下を変更
- app/controllers/gift_records_controller.rb
- app/javascript/controllers/favorites_controller.js
- app/models/gift_item_category.rb
- app/models/gift_record.rb
- app/views/gift_records/_form.html.erb
- app/views/shared/_favorite_button.html.erb
- db/migrate/20250813051318_create_gift_item_categories.rb
- 

## 関連Issue
#101 #114