### PR TITLE
change:ユーザー名の文字数制限を20から10へ変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :reminds, dependent: :destroy
 
   # バリデーション
-  validates :name, presence: true, length: { maximum: 20 }
+  validates :name, presence: true, length: { maximum: 10 }
 
   # セキュリティを考慮したエラーメッセージの置き換え
   after_validation :customize_validation_errors

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,14 +8,8 @@
     margin: 0 auto;
     position: relative;
   ">
-    <h2 style="
-      margin: 0 0 40px 0;
-      padding: 0;
-      font-size: 28px;
-      font-weight: 600;
-      color: #333;
-      line-height: 1.4;
-    ">新規登録</h2>
+
+  <h2 class="text-2xl font-semibold text-gray-800 mb-10  ">新規登録</h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
@@ -40,7 +34,7 @@
           margin-top: 8px;
         " %>
         <small style="display: block; margin-top: 4px; color: #6c757d; font-size: 12px;">
-          20文字以内で入力してください。他のユーザーに表示される名前です。
+          10文字以内で入力してください。他のユーザーに表示される名前です。
         </small>
       </div>
 


### PR DESCRIPTION
## 概要
ユーザー名の文字数制限が多過ぎたため20から10へ変更


## 主な変更点
以下を変更
- app/models/user.rb
- app/views/devise/registrations/new.html.erb

## 関連Issue
#130