### PR TITLE
hotfix:String does not have #dig method (TypeError)によりデプロイ失敗の修正

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,10 +9,6 @@ local:
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
   service: S3
-  # access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  # secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  # region: us-east-1
-  # bucket: your_own_bucket-<%= Rails.env %>
   access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['AWS_REGION'] %>


### PR DESCRIPTION
## 概要
String does not have #dig method (TypeError)によりデプロイ失敗の修正
config/storage.ymlの不用文言の削除

## 主な変更点
以下を変更
- config/storage.yml

## 関連Issue
#132