### PR TITLE
hotfix:ギフト画像の投稿時にredisのエラーが発生するため修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,4 +100,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.active_storage.analyze = false
 end


### PR DESCRIPTION
## 概要
ギフト画像の投稿時にredisのエラーが発生するため修正

## 主な変更点
以下を変更
- config/environments/production.rb

## 関連Issue
#132