### PR TITLE
Add/ギフト相手の住所カラムを追加

### DIFF
--- a/app/controllers/admin/gift_people_controller.rb
+++ b/app/controllers/admin/gift_people_controller.rb
@@ -56,6 +56,6 @@ class Admin::GiftPeopleController < Admin::BaseController
   end
 
   def gift_person_params
-    params.require(:gift_person).permit(:name, :relationship_id)
+    params.require(:gift_person).permit(:name, :relationship_id, :birthday, :likes, :dislikes, :address, :memo, :avatar)
   end
 end

--- a/app/controllers/gift_people_controller.rb
+++ b/app/controllers/gift_people_controller.rb
@@ -233,7 +233,7 @@ class GiftPeopleController < ApplicationController
   private
 
   def gift_person_params
-    params.require(:gift_person).permit(:name, :relationship_id, :birthday, :likes, :dislikes, :memo, :avatar, :remove_avatar)
+    params.require(:gift_person).permit(:name, :relationship_id, :birthday, :likes, :dislikes, :address, :memo, :avatar, :remove_avatar)
   end
 
   def set_gift_person

--- a/app/controllers/gift_records_controller.rb
+++ b/app/controllers/gift_records_controller.rb
@@ -446,7 +446,7 @@ class GiftRecordsController < ApplicationController
   end
 
   def gift_person_params
-    params.require(:gift_person).permit(:name, :relationship_id, :birthday, :likes, :dislikes, :memo)
+    params.require(:gift_person).permit(:name, :relationship_id, :birthday, :likes, :dislikes, :address, :memo)
   end
 
   # セキュリティ: ギフト記録を取得

--- a/app/models/gift_person.rb
+++ b/app/models/gift_person.rb
@@ -7,6 +7,7 @@ class GiftPerson < ApplicationRecord
 
   validates :name, presence: true, length: { minimum: 1 }
   validates :name, format: { with: /\A\S+.*\S*\z/, message: "空白のみは無効です" }
+  validates :address, length: { maximum: 100 }, allow_blank: true
   validate :avatar_validation
 
   # 指定された日付時点での年齢を計算

--- a/app/views/gift_people/_form.html.erb
+++ b/app/views/gift_people/_form.html.erb
@@ -330,6 +330,49 @@
     <% end %>
   </div>
 
+  <!-- 住所入力 -->
+  <div style="margin-bottom: 24px; text-align: left;">
+    <%= f.label :address, "住所", style: "
+      display: block;
+      margin-bottom: 8px;
+      font-weight: 600;
+      color: #555;
+      font-size: 14px;
+    " %>
+    <%= f.text_area :address, 
+        data: { 
+          "gift-person-form-target": "input",
+          "action": local_assigns[:new_mode] ? "input->gift-person-form#inputChanged" : nil
+        }.compact,
+        style: "
+          width: 100%;
+          padding: 14px 16px;
+          border: 2px solid #e1e5e9;
+          border-radius: 8px;
+          font-size: 16px;
+          box-sizing: border-box;
+          transition: border-color 0.3s ease;
+          min-height: 80px;
+          resize: vertical;
+        ",
+        placeholder: "例：東京都新宿区西新宿x-x-x、〒xxx-xxxxx",
+        maxlength: 100 %>
+    
+    <!-- ヘルプテキスト -->
+    <div style="font-size: 12px; color: #888; margin-top: 8px;">
+      <i class="fas fa-info-circle" style="margin-right: 4px;"></i>
+      相手の住所を記録しておくと、配送先として便利です（任意、最大100文字）
+    </div>
+    
+    <!-- エラーメッセージ -->
+    <% if gift_person.errors[:address].any? %>
+      <div style="color: #dc3545; font-size: 12px; margin-top: 8px;">
+        <i class="fas fa-exclamation-triangle" style="margin-right: 4px;"></i>
+        <%= gift_person.errors[:address].first %>
+      </div>
+    <% end %>
+  </div>
+
   <!-- メモ入力 -->
   <div style="margin-bottom: 32px; text-align: left;">
     <%= f.label :memo, "メモ", style: "

--- a/app/views/gift_people/show.html.erb
+++ b/app/views/gift_people/show.html.erb
@@ -116,6 +116,17 @@
         </div>
       </div>
 
+      <div class="mb-6">
+        <label class="block mb-2 font-semibold text-gray-700 text-sm">住所</label>
+        <div class="w-full p-4 border-2 border-gray-300 rounded-lg text-base bg-gray-50 text-gray-900 min-h-20">
+          <% if @gift_person.address.present? %>
+            <%= simple_format(@gift_person.address, class: "m-0 whitespace-pre-line") %>
+          <% else %>
+            <span class="text-gray-500">未記録</span>
+          <% end %>
+        </div>
+      </div>
+
       <% if @gift_person.memo.present? %>
         <div class="mb-6">
           <label class="block mb-2 font-semibold text-gray-700 text-sm">メモ</label>

--- a/app/views/gift_records/_form.html.erb
+++ b/app/views/gift_records/_form.html.erb
@@ -279,6 +279,30 @@
             id: "gift_person_dislikes" %>
       </div>
       
+      <div style="margin-bottom: 16px;">
+        <%= label_tag "gift_person_address", "住所", style: "
+          display: block;
+          margin-bottom: 8px;
+          font-weight: 600;
+          color: #555;
+          font-size: 14px;
+        " %>
+        <%= text_area_tag "gift_person[address]", @gift_person&.address || params.dig(:gift_person, :address), 
+            style: "
+              width: 100%;
+              padding: 12px 16px;
+              border: 2px solid #e1e5e9;
+              border-radius: 6px;
+              font-size: 14px;
+              box-sizing: border-box;
+              min-height: 80px;
+              resize: vertical;
+            ",
+            placeholder: "例：東京都新宿区西新宿x-x-x、〒xxx-xxxxx",
+            maxlength: 100,
+            id: "gift_person_address" %>
+      </div>
+      
       <div style="margin-bottom: 0;">
         <%= label_tag "gift_person_memo", "メモ", style: "
           display: block;

--- a/db/migrate/20250822000120_change_address_null_on_gift_people.rb
+++ b/db/migrate/20250822000120_change_address_null_on_gift_people.rb
@@ -1,0 +1,5 @@
+class ChangeAddressNullOnGiftPeople < ActiveRecord::Migration[7.2]
+  def change
+        change_column :gift_people, :address, :string, null: true, comment: '住所'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_21_234153) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_22_000120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -91,7 +91,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_21_234153) do
     t.bigint "relationship_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "address"
+    t.string "address", comment: "住所"
     t.index ["relationship_id"], name: "index_gift_people_on_relationship_id"
     t.index ["user_id"], name: "index_gift_people_on_user_id"
   end


### PR DESCRIPTION
## 概要
ギフト相手の住所カラムを追加
ギフト記録時のギフト相手フォームや新たなギフト相手

## 主な変更点
以下を変更
- app/controllers/admin/gift_people_controller.rb
- app/controllers/gift_people_controller.rb
- app/controllers/gift_records_controller.rb
- app/models/gift_person.rb
- app/views/gift_people/_form.html.erb
- app/views/gift_people/show.html.erb
- app/views/gift_records/_form.html.erb
- db/migrate/20250822000120_change_address_null_on_gift_people.rb

## 関連Issue
#165