### PR TITLE
fix/iosでギフト記録時のプルダウン項目を選択時に選択後すぐ解除されてしまうのを修正

### DIFF
--- a/app/javascript/controllers/gift_records_controller.js
+++ b/app/javascript/controllers/gift_records_controller.js
@@ -40,6 +40,15 @@ export default class extends Controller {
     this.initializeFormValidation()
   }
 
+  // 共通: 不要なバブリングを抑止（モバイルでの二重発火対策）
+  stopEvent(event) {
+    if (event) {
+      if (typeof event.stopPropagation === 'function') event.stopPropagation()
+      // iOS/Safari でのネイティブ UI 操作時の不意な既定動作抑止は避ける
+      // ここでは preventDefault は行わず、バブリングのみ止める
+    }
+  }
+
   // ギフト相手選択の初期化
   initializeGiftPersonFields() {
     if (this.hasGiftPeopleSelectTarget && this.hasNewGiftPersonFieldsTarget) {

--- a/app/views/gift_records/_form.html.erb
+++ b/app/views/gift_records/_form.html.erb
@@ -59,7 +59,7 @@
           ",
           id: "gift_record_event_id",
           required: true,
-          data: { gift_records_target: "eventSelect", event_selector_target: "select" }
+          data: { gift_records_target: "eventSelect", event_selector_target: "select", action: "change->gift-records#stopEvent click->gift-records#stopEvent" }
         } %>
     
     <!-- ヘルプテキスト -->
@@ -147,7 +147,7 @@
           required: true,
           data: { 
             gift_records_target: "giftPeopleSelect",
-            action: "change->gift-records#giftPersonChanged"
+            action: "change->gift-records#giftPersonChanged change->gift-records#stopEvent click->gift-records#stopEvent"
           }
         } %>
 
@@ -241,7 +241,8 @@
                 background-color: white;
                 color: black;
               ",
-              id: "gift_person_relationship_id"
+              id: "gift_person_relationship_id",
+              data: { action: "change->gift-records#stopEvent click->gift-records#stopEvent" }
             } %>
       </div>
       
@@ -544,7 +545,8 @@
               background-color: white;
               color: black;
             ",
-            id: "gift_record_gift_item_category_id"
+            id: "gift_record_gift_item_category_id",
+            data: { action: "change->gift-records#stopEvent click->gift-records#stopEvent" }
           }
     %>
 


### PR DESCRIPTION
## 概要
iosでギフト記録時のプルダウン項目を選択時に選択後すぐ解除されてしまうのを修正

## 主な変更点
以下を変更
- app/javascript/controllers/gift_records_controller.js
- app/views/gift_records/_form.html.erb

## 関連Issue
#288