### PR TITLE
update:メモの上限を300文字に変更

### DIFF
--- a/app/models/gift_record.rb
+++ b/app/models/gift_record.rb
@@ -46,7 +46,7 @@ class GiftRecord < ApplicationRecord
 
   # オプションフィールドのバリデーション
   validates :amount, numericality: { greater_than: 0, allow_nil: true }
-  validates :memo, length: { maximum: 100 }
+  validates :memo, length: { maximum: 300 }
 
   # カスタムバリデーション
   validate :gift_at_is_valid_date

--- a/app/views/admin/gift_records/edit.html.erb
+++ b/app/views/admin/gift_records/edit.html.erb
@@ -142,11 +142,11 @@
               rows: 4,
               class: "block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 #{@gift_record.errors[:memo].any? ? 'border-red-300 focus:ring-red-500 focus:border-red-500' : ''}",
               placeholder: "このギフトに関するメモや思い出を記録...",
-              maxlength: 1000 %>
+              maxlength: 300 %>
           
           <!-- 文字数カウンタ -->
           <div class="mt-1 text-xs text-gray-400 text-right">
-            <span id="memo-count">0</span>/1000文字
+            <span id="memo-count">0</span>/300文字
           </div>
           
           <!-- ヘルプテキスト -->

--- a/app/views/gift_records/_form.html.erb
+++ b/app/views/gift_records/_form.html.erb
@@ -655,11 +655,11 @@
         ",
         placeholder: "ギフトに関するメモ、思い出、相手の反応など...",
         class: "gift-form-input",
-        maxlength: 100 %>
+        maxlength: 300 %>
     
     <div style="font-size: 12px; color: #888; margin-top: 8px;">
       <i class="fas fa-info-circle" style="margin-right: 4px;"></i>
-      ギフトに関する思い出やメモを自由に記録してください（任意、最大100文字）
+      ギフトに関する思い出やメモを自由に記録してください（任意、最大300文字）
     </div>
     
     <% if gift_record.errors[:memo].any? %>

--- a/spec/models/gift_record_spec.rb
+++ b/spec/models/gift_record_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe GiftRecord, type: :model do
         expect(subject).to be_invalid
       end
 
-      it 'memoは100文字以下である' do
-        subject.memo = 'a' * 101
+      it 'memoは300文字以下である' do
+        subject.memo = 'a' * 301
         expect(subject).to be_invalid
       end
     end


### PR DESCRIPTION
## 概要
メモの上限を300文字に変更

## 主な変更点
以下を変更
- app/models/gift_record.rb
- app/views/admin/gift_records/edit.html.erb
- app/views/gift_records/_form.html.erb
- spec/models/gift_record_spec.rb

## 関連Issue
#390